### PR TITLE
Fixed missing MERORDERNUM parameter in the response parameters list in the Sorter

### DIFF
--- a/src/Param/Utils/Sorter.php
+++ b/src/Param/Utils/Sorter.php
@@ -48,6 +48,7 @@ class Sorter
     public const RESPONSE_PARAM_ORDER = [
         Param::OPERATION,
         Param::ORDERNUMBER,
+        Param::MERORDERNUM,
         Param::MERCHANTNUMBER,
         Param::MD,
         Response::PRCODE,

--- a/tests/Param/Utils/SorterTest.php
+++ b/tests/Param/Utils/SorterTest.php
@@ -72,6 +72,7 @@ class SorterTest extends TestCase
             Response::ACCODE => new FakeParam('someparam'),
             Response::DIGEST1 => new FakeParam('someparam'),
             Param::PANPATTERN => new FakeParam('someparam'),
+            Param::MERORDERNUM => new FakeParam('someparam'),
             Response::DAYTOCAPTURE => new FakeParam('someparam'),
             Response::TOKENREGSTATUS => new FakeParam('someparam'),
             Param::DIGEST => new FakeParam('someparam'),


### PR DESCRIPTION
I had troubles with the response DIGEST while using the MERORDERNUM parameter. The DIGEST from the gate didn't match the DIGEST calculated locally.

Then I realized that the parameter MERORDERNUM is missing in the Sorter class causing the DIGEST string looking something like this:

```
CREATE_ORDER|157487125803|0|0|OK|155912254545    <- this is wrong
```

instead of this:

```
CREATE_ORDER|157487125803|155912254545|0|0|OK    <- this is correct
```

Just adding the parameter into the list fixes the problem.